### PR TITLE
feat(parser): Support parsing courses from a Github repository

### DIFF
--- a/cmd/topic.js
+++ b/cmd/topic.js
@@ -1,9 +1,8 @@
-const path = require('path');
 const course = require('../lib/course');
 
 
 module.exports = app => course(
-  path.resolve(app.args.shift()),
+  app.args.shift(),
   app.models,
   app.opts,
 );

--- a/index.js
+++ b/index.js
@@ -4,7 +4,7 @@ const minimist = require('minimist');
 const chalk = require('chalk');
 const mongoose = require('mongoose');
 const models = require('models')(mongoose);
-const { hasOwnProperty } = require('./lib/common');
+const { hasOwnProperty, isGithubUrl } = require('./lib/common');
 const pkg = require('./package.json');
 
 
@@ -59,6 +59,15 @@ module.exports = (args, opts) => {
   if (opts.h || opts.help || cmdName === 'help') {
     return commands.help({ pkg, commands })
       .then(success, error);
+  }
+
+  const isGithubRepoUrl = isGithubUrl(args[0]);
+  if (isGithubRepoUrl && !opts.token) {
+    return error(new Error('Missing access token. Get one at https://github.com/settings/tokens'));
+  }
+
+  if (isGithubRepoUrl && !opts.branch) {
+    return error(new Error('Missing branch'));
   }
 
   const requiredArgs = (commands[cmdName].args || []).reduce(

--- a/lib/common.js
+++ b/lib/common.js
@@ -408,3 +408,5 @@ exports.getReadmeFileName = locale => (
     ? 'README.md'
     : `README.${locale}.md`
 );
+
+exports.isGithubUrl = str => /^https?:\/\/github.com\//.test(str);

--- a/lib/course.js
+++ b/lib/course.js
@@ -3,6 +3,7 @@ const path = require('path');
 const { promisify } = require('util');
 const marked = require('marked');
 const { JSDOM } = require('jsdom');
+const Octokit = require('./octokit');
 const common = require('./common');
 const syllabus = require('./syllabus');
 const { computeCourseStats } = require('./stats');
@@ -135,44 +136,40 @@ const parseTokens = (tokens) => {
 };
 
 
-const parseCourseReadme = readme => promisify(fs.readFile)(readme, 'utf8')
-  .then(text => marked.lexer(text || ''))
-  .then((tokens) => {
-    if (!tokens.length) {
-      throw Object.assign(new Error('README.md del curso está vacío'), {
-        path: readme,
-      });
+const parseCourseReadme = (readme, location) => {
+  const tokens = marked.lexer(readme || '');
+  if (!tokens.length) {
+    throw Object.assign(new Error('README.md del curso está vacío'), {
+      path: location,
+    });
+  }
+
+  if (tokens[0].type !== 'heading' || tokens[0].depth !== 1) {
+    throw Object.assign(
+      new Error('README.md del curso debe empezar con un h1 con el título del curso'),
+      { path: location },
+    );
+  }
+
+  const parsed = parseTokens(tokens);
+
+  return Object.keys(parsed).reduce((memo, key) => {
+    if (key === 'title') {
+      return { ...memo, [key]: parsed[key] };
     }
-
-    if (tokens[0].type !== 'heading' || tokens[0].depth !== 1) {
-      throw Object.assign(
-        new Error('README.md del curso debe empezar con un h1 con el título del curso'),
-        { path: readme },
-      );
+    if (key === 'description') {
+      const { description, tags } = parseDescription(parsed[key], tokens.links);
+      return { ...memo, [key]: description, tags };
     }
-
-    const parsed = parseTokens(tokens);
-
-    return Object.keys(parsed).reduce((memo, key) => {
-      if (key === 'title') {
-        return { ...memo, [key]: parsed[key] };
-      }
-      if (key === 'description') {
-        const { description, tags } = parseDescription(parsed[key], tokens.links);
-        return { ...memo, [key]: description, tags };
-      }
-      if (key === 'syllabus') {
-        return { ...memo, [key]: parseSyllabus(parsed[key], tokens.links) };
-      }
-      if (key !== 'tags') {
-        return { ...memo, [key]: common.tokensToHTML(parsed[key], tokens.links) };
-      }
-      return memo;
-    }, {});
-  })
-  .catch((err) => {
-    throw Object.assign(err, { path: readme });
-  });
+    if (key === 'syllabus') {
+      return { ...memo, [key]: parseSyllabus(parsed[key], tokens.links) };
+    }
+    if (key !== 'tags') {
+      return { ...memo, [key]: common.tokensToHTML(parsed[key], tokens.links) };
+    }
+    return memo;
+  }, {});
+};
 
 
 // mezcla el syllabus leido en el README.md principal con las unidades leídas
@@ -263,12 +260,41 @@ const applyGlobalOptions = (result, opts, relativePath, parserVersion) => ({
 //
 
 
-module.exports = (dir, { Topic }, opts = {}) => {
-  const readme = path.join(dir, common.getReadmeFileName(opts.locale));
-  const relativePath = path.relative(process.cwd(), dir);
-  const { slug } = common.parseDirname(readme);
+module.exports = async (dirOrPath, { Topic }, opts = {}) => {
+  let readme;
+  let relativePath;
+  let slug;
+  let dir;
+  let location;
 
-  return Promise.all([parseCourseReadme(readme), syllabus(dir, opts)])
+  const readmeFileName = common.getReadmeFileName(opts.locale);
+  if (common.isGithubUrl(dirOrPath)) {
+    const { repo, token, branch } = opts;
+    const [username, repository] = repo.split('/');
+    const octokit = Octokit({
+      auth: token,
+    });
+    const { data } = await octokit.repos.getContents({
+      owner: username,
+      repo: repository,
+      path: readmeFileName,
+      ref: branch,
+    });
+    readme = Buffer.from(data.content, 'base64').toString();
+    relativePath = dirOrPath;
+    // TODO: Check with the team if this is fine
+    slug = `${repository}-${branch}`;
+    location = dirOrPath;
+  } else {
+    dir = path.resolve(dirOrPath);
+    const readmePath = path.join(dir, readmeFileName);
+    readme = await promisify(fs.readFile)(readmePath, 'utf8');
+    relativePath = path.relative(process.cwd(), dir);
+    slug = common.parseDirname(readmePath).slug;
+    location = readmePath;
+  }
+
+  return Promise.all([parseCourseReadme(readme, location), syllabus(dirOrPath, opts)])
     .then(([course, syllabusFromSubdirs]) => merge(course, syllabusFromSubdirs))
     .then(merged => computeUnitsOrder(merged))
     .then(result => ({ slug, createdAt: new Date(), ...result }))

--- a/lib/octokit.js
+++ b/lib/octokit.js
@@ -1,0 +1,6 @@
+const Octokit = require('@octokit/rest');
+
+module.exports = ({ auth }) => Octokit({
+  auth,
+  userAgent: 'Laboratoria/curriculum-parser',
+});

--- a/lib/part.js
+++ b/lib/part.js
@@ -1,6 +1,7 @@
 const fs = require('fs');
 const path = require('path');
 const { promisify } = require('util');
+const Octokit = require('@octokit/rest');
 const common = require('./common');
 const exercise = require('./exercise');
 const quiz = require('./quiz');
@@ -34,30 +35,91 @@ const partFormats = {
   individual: 'self-paced',
 };
 
+const metaKeys = {
+  tipo: 'type',
+  type: 'type',
+  formato: 'format',
+  format: 'format',
+  duración: 'duration',
+  duration: 'duration',
+  duração: 'duration',
+};
 
-module.exports = (dir, opts = {}) => {
+module.exports = async (dirOrPath, opts = {}) => {
   const readmeFileName = common.getReadmeFileName(opts.locale);
-  const readmeAbsPath = path.join(dir, readmeFileName);
 
+  if (opts.branch && opts.token) {
+    const { repo, token, branch } = opts;
+    const [username, repository] = repo.split('/');
+    const octokit = Octokit({
+      auth: token,
+    });
+
+    try {
+      const { data } = await octokit.repos.getContents({
+        owner: username,
+        repo: repository,
+        path: `${dirOrPath}/${readmeFileName}`,
+        ref: branch,
+      });
+
+      const readme = Buffer.from(data.content, 'base64').toString();
+      const parsedReadme = common.parseReadme(readme, metaKeys);
+      Object.assign(parsedReadme, {
+        duration: common.parseDuration(parsedReadme.duration),
+        format: partFormats[parsedReadme.format],
+        type: partTypes[parsedReadme.type],
+      });
+
+      if (parsedReadme.duration === null) {
+        throw Object.assign(new Error('Could not parse part duration'), {
+          path: dirOrPath,
+          type: 'part',
+        });
+      }
+
+      // TODO: Support parsing of `practice` type parts
+      // Not a priority for CT courses
+
+      if (parsedReadme.type === 'quiz') {
+        return Object.keys(parsedReadme).reduce(
+          (memo, key) => (
+            (key === 'body')
+              ? memo
+              : { ...memo, [key]: parsedReadme[key] }
+          ),
+          {
+            questions: quiz(parsedReadme.body),
+          },
+        );
+      }
+
+      return parsedReadme;
+    } catch (err) {
+      if (err.status === 404) {
+        throw Object.assign(new Error('Part is missing README.md'), {
+          path: dirOrPath,
+          type: 'part',
+        });
+      }
+    }
+  }
+
+  const dir = path.resolve(dirOrPath);
   return promisify(fs.readdir)(dir)
     .then((files) => {
       if (files.indexOf(readmeFileName) === -1) {
-        throw new Error('Part is missing README.md');
+        throw Object.assign(new Error('Part is missing README.md'), {
+          path: dirOrPath,
+          type: 'part',
+        });
       }
 
-      return promisify(fs.readFile)(readmeAbsPath, 'utf8')
+      return promisify(fs.readFile)(path.join(dirOrPath, readmeFileName), 'utf8')
         .then(readme => [readme, files]);
     })
     .then(([readme, files]) => {
-      const parsedReadme = common.parseReadme(readme, {
-        tipo: 'type',
-        type: 'type',
-        formato: 'format',
-        format: 'format',
-        duración: 'duration',
-        duration: 'duration',
-        duração: 'duration',
-      });
+      const parsedReadme = common.parseReadme(readme, metaKeys);
 
       Object.assign(parsedReadme, {
         duration: common.parseDuration(parsedReadme.duration),
@@ -66,14 +128,17 @@ module.exports = (dir, opts = {}) => {
       });
 
       if (parsedReadme.duration === null) {
-        throw new Error('Could not parse part duration');
+        throw Object.assign(new Error('Could not parse part duration'), {
+          path: dirOrPath,
+          type: 'part',
+        });
       }
 
       if (parsedReadme.type === 'practice') {
         return Promise.all(
           files
             .filter(common.isDirname)
-            .map(file => exercise(path.join(dir, file), opts)),
+            .map(file => exercise(path.join(dirOrPath, file), opts)),
         )
           .then(all => all.reduce(
             (memo, { slug, ...item }) => ({ ...memo, [slug]: item }),
@@ -100,8 +165,5 @@ module.exports = (dir, opts = {}) => {
       }
 
       return parsedReadme;
-    })
-    .catch((err) => {
-      throw Object.assign(err, { path: readmeAbsPath });
     });
 };

--- a/lib/syllabus.js
+++ b/lib/syllabus.js
@@ -1,24 +1,48 @@
 const fs = require('fs');
 const path = require('path');
 const { promisify } = require('util');
+const Octokit = require('./octokit');
 const { isDirname } = require('./common');
 const unit = require('./unit');
 
 
 //
-// Read syllabus from filesystem (not from main readme).
+// Read syllabus from filesystem or Github repository (not from main readme).
 //
-module.exports = (dir, opts) => promisify(fs.readdir)(dir)
-  .then(files => files.filter(isDirname))
-  .then(
-    unitDirs => Promise.all(
-      unitDirs.map(unitDir => unit(path.join(dir, unitDir), opts)),
-    )
-      .then(units => units.reduce(
-        (memo, item, idx) => ({
-          ...memo,
-          [unitDirs[idx]]: item,
-        }),
-        {},
-      )),
-  );
+module.exports = async (dirOrPath, opts) => {
+  if (opts.branch && opts.token) {
+    const { repo, token, branch } = opts;
+    const [username, repository] = repo.split('/');
+    const octokit = Octokit({
+      auth: token,
+    });
+    const { data } = await octokit.repos.getContents({
+      owner: username,
+      repo: repository,
+      path: '',
+      ref: branch,
+    });
+    const unitDirs = data.filter(file => file.type === 'dir');
+    const units = await Promise.all(unitDirs.map(unitDir => unit(unitDir.path, opts)));
+    return units.reduce((memo, item, idx) => ({
+      ...memo,
+      [unitDirs[idx].name]: item,
+    }), {});
+  }
+
+  const dir = path.resolve(dirOrPath);
+  return promisify(fs.readdir)(dir)
+    .then(files => files.filter(isDirname))
+    .then(
+      unitDirs => Promise.all(
+        unitDirs.map(unitDir => unit(path.join(dirOrPath, unitDir), opts)),
+      )
+        .then(units => units.reduce(
+          (memo, item, idx) => ({
+            ...memo,
+            [unitDirs[idx]]: item,
+          }),
+          {},
+        )),
+    );
+};

--- a/lib/unit.js
+++ b/lib/unit.js
@@ -1,21 +1,45 @@
 const fs = require('fs');
 const path = require('path');
 const { promisify } = require('util');
+const Octokit = require('./octokit');
 const { isDirname } = require('./common');
 const part = require('./part');
 
 
-module.exports = (dir, opts) => promisify(fs.readdir)(dir)
-  .then(files => files.filter(isDirname))
-  .then(
-    partDirs => Promise.all(
-      partDirs.map(partDir => part(path.join(dir, partDir), opts)),
-    )
-      .then(parts => parts.reduce(
-        (memo, item, idx) => ({
-          ...memo,
-          [partDirs[idx]]: item,
-        }),
-        {},
-      )),
-  );
+module.exports = async (dirOrPath, opts = {}) => {
+  if (opts.branch && opts.token) {
+    const { repo, token, branch } = opts;
+    const [username, repository] = repo.split('/');
+    const octokit = Octokit({
+      auth: token,
+    });
+    const { data } = await octokit.repos.getContents({
+      owner: username,
+      repo: repository,
+      path: dirOrPath,
+      ref: branch,
+    });
+    const partDirs = data.filter(file => file.type === 'dir');
+    const parts = await Promise.all(partDirs.map(partDir => part(partDir.path, opts)));
+    return parts.reduce((memo, item, idx) => ({
+      ...memo,
+      [partDirs[idx].name]: item,
+    }), {});
+  }
+
+  const dir = path.resolve(dirOrPath);
+  return promisify(fs.readdir)(dir)
+    .then(files => files.filter(isDirname))
+    .then(
+      partDirs => Promise.all(
+        partDirs.map(partDir => part(path.join(dirOrPath, partDir), opts)),
+      )
+        .then(parts => parts.reduce(
+          (memo, item, idx) => ({
+            ...memo,
+            [partDirs[idx]]: item,
+          }),
+          {},
+        )),
+    );
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -394,6 +394,87 @@
       "resolved": "https://registry.npmjs.org/@laboratoria/rubric/-/rubric-3.0.3.tgz",
       "integrity": "sha512-JTFSwh9WyujvUN/3wQGhLmyFUR43A1XChkj/qDkRDWE3w7jf8BUhZCwhdnefboHZjW2D90Ayr0dhZYU8bPyDDQ=="
     },
+    "@octokit/endpoint": {
+      "version": "5.3.6",
+      "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-5.3.6.tgz",
+      "integrity": "sha512-XuerByak8H+jW9J/rVMEdBXfI4UTsDWUwAKgIP/uhQjXIUVdPRwt2Zg+SmbWQ+WY7pRkw/hFVES8C4G/Kle7oA==",
+      "requires": {
+        "is-plain-object": "^3.0.0",
+        "universal-user-agent": "^4.0.0"
+      },
+      "dependencies": {
+        "is-plain-object": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-3.0.0.tgz",
+          "integrity": "sha512-tZIpofR+P05k8Aocp7UI/2UTa9lTJSebCXpFFoR9aibpokDj/uXBsJ8luUu0tTVYKkMU6URDUuOfJZ7koewXvg==",
+          "requires": {
+            "isobject": "^4.0.0"
+          }
+        },
+        "isobject": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/isobject/-/isobject-4.0.0.tgz",
+          "integrity": "sha512-S/2fF5wH8SJA/kmwr6HYhK/RI/OkhD84k8ntalo0iJjZikgq1XFvR5M8NPT1x5F7fBwCG3qHfnzeP/Vh/ZxCUA=="
+        }
+      }
+    },
+    "@octokit/request": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@octokit/request/-/request-5.1.0.tgz",
+      "integrity": "sha512-I15T9PwjFs4tbWyhtFU2Kq7WDPidYMvRB7spmxoQRZfxSmiqullG+Nz+KbSmpkfnlvHwTr1e31R5WReFRKMXjg==",
+      "requires": {
+        "@octokit/endpoint": "^5.1.0",
+        "@octokit/request-error": "^1.0.1",
+        "deprecation": "^2.0.0",
+        "is-plain-object": "^3.0.0",
+        "node-fetch": "^2.3.0",
+        "once": "^1.4.0",
+        "universal-user-agent": "^4.0.0"
+      },
+      "dependencies": {
+        "is-plain-object": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-3.0.0.tgz",
+          "integrity": "sha512-tZIpofR+P05k8Aocp7UI/2UTa9lTJSebCXpFFoR9aibpokDj/uXBsJ8luUu0tTVYKkMU6URDUuOfJZ7koewXvg==",
+          "requires": {
+            "isobject": "^4.0.0"
+          }
+        },
+        "isobject": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/isobject/-/isobject-4.0.0.tgz",
+          "integrity": "sha512-S/2fF5wH8SJA/kmwr6HYhK/RI/OkhD84k8ntalo0iJjZikgq1XFvR5M8NPT1x5F7fBwCG3qHfnzeP/Vh/ZxCUA=="
+        }
+      }
+    },
+    "@octokit/request-error": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-1.0.4.tgz",
+      "integrity": "sha512-L4JaJDXn8SGT+5G0uX79rZLv0MNJmfGa4vb4vy1NnpjSnWDLJRy6m90udGwvMmavwsStgbv2QNkPzzTCMmL+ig==",
+      "requires": {
+        "deprecation": "^2.0.0",
+        "once": "^1.4.0"
+      }
+    },
+    "@octokit/rest": {
+      "version": "16.30.1",
+      "resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-16.30.1.tgz",
+      "integrity": "sha512-1n2QzTbbaBXNLpx7WHlcsSMdJvxSdKmerXQm+bMYlKDbQM19uq446ZpGs7Ynq5SsdLj1usIfgJ9gJf4LtcWkDw==",
+      "requires": {
+        "@octokit/request": "^5.0.0",
+        "@octokit/request-error": "^1.0.2",
+        "atob-lite": "^2.0.0",
+        "before-after-hook": "^2.0.0",
+        "btoa-lite": "^1.0.0",
+        "deprecation": "^2.0.0",
+        "lodash.get": "^4.4.2",
+        "lodash.set": "^4.3.2",
+        "lodash.uniq": "^4.5.0",
+        "octokit-pagination-methods": "^1.1.0",
+        "once": "^1.4.0",
+        "universal-user-agent": "^4.0.0"
+      }
+    },
     "@types/babel__core": {
       "version": "7.1.3",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.1.3.tgz",
@@ -649,6 +730,11 @@
       "integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==",
       "dev": true
     },
+    "atob-lite": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/atob-lite/-/atob-lite-2.0.0.tgz",
+      "integrity": "sha1-D+9a1G8b16hQLGVyfwNn1e5D1pY="
+    },
     "aws-sign2": {
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
@@ -819,6 +905,11 @@
         "tweetnacl": "^0.14.3"
       }
     },
+    "before-after-hook": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-2.1.0.tgz",
+      "integrity": "sha512-IWIbu7pMqyw3EAJHzzHbWa85b6oud/yfKYg5rqB5hNE8CeMi3nX+2C2sj0HswfblST86hpVEOAb9x34NZd6P7A=="
+    },
     "bluebird": {
       "version": "3.0.5",
       "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.0.5.tgz",
@@ -898,6 +989,11 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/bson/-/bson-1.1.1.tgz",
       "integrity": "sha512-jCGVYLoYMHDkOsbwJZBCqwMHyH4c+wzgI9hG7Z6SZJRXWr+x58pdIbm2i9a/jFGCkRJqRUr8eoI7lDWa0hTkxg=="
+    },
+    "btoa-lite": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/btoa-lite/-/btoa-lite-1.0.0.tgz",
+      "integrity": "sha1-M3dm2hWAEhD92VbCLpxokaudAzc="
     },
     "buffer-from": {
       "version": "1.1.1",
@@ -1146,7 +1242,6 @@
       "version": "6.0.5",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
       "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
-      "dev": true,
       "requires": {
         "nice-try": "^1.0.4",
         "path-key": "^2.0.1",
@@ -1158,8 +1253,7 @@
         "semver": {
           "version": "5.7.1",
           "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
-          "dev": true
+          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
         }
       }
     },
@@ -1281,6 +1375,11 @@
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
     },
+    "deprecation": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/deprecation/-/deprecation-2.3.1.tgz",
+      "integrity": "sha512-xmHIy4F3scKVwMsQ4WnVaS8bHOx0DmVwRywosKhaILI0ywMDWPtBSku2HNxRvF7jtwDRsoEwYQSfbxj8b7RlJQ=="
+    },
     "detect-newline": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-2.1.0.tgz",
@@ -1329,7 +1428,6 @@
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.1.tgz",
       "integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
-      "dev": true,
       "requires": {
         "once": "^1.4.0"
       }
@@ -1643,7 +1741,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/execa/-/execa-1.0.0.tgz",
       "integrity": "sha512-adbxcyWV46qiHyvSp50TKt05tB4tK3HcmF7/nxfAdhnox83seTDbwnaqKO4sXRy7roHAIFqJP/Rw/AuEbX61LA==",
-      "dev": true,
       "requires": {
         "cross-spawn": "^6.0.0",
         "get-stream": "^4.0.0",
@@ -2528,7 +2625,6 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
       "integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
-      "dev": true,
       "requires": {
         "pump": "^3.0.0"
       }
@@ -3021,8 +3117,7 @@
     "is-stream": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
-      "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
-      "dev": true
+      "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
     },
     "is-symbol": {
       "version": "1.0.2",
@@ -3059,8 +3154,7 @@
     "isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
-      "dev": true
+      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
     },
     "isobject": {
       "version": "3.0.1",
@@ -3838,10 +3932,25 @@
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
       "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
     },
+    "lodash.get": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
+      "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk="
+    },
+    "lodash.set": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/lodash.set/-/lodash.set-4.3.2.tgz",
+      "integrity": "sha1-2HV7HagH3eJIFrDWqEvqGnYjCyM="
+    },
     "lodash.sortby": {
       "version": "4.7.0",
       "resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
       "integrity": "sha1-7dFMgk4sycHgsKG0K7UhBRakJDg="
+    },
+    "lodash.uniq": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz",
+      "integrity": "sha1-0CJTc662Uq3BvILklFM5qEJ1R3M="
     },
     "log-driver": {
       "version": "1.2.7",
@@ -3857,6 +3966,11 @@
       "requires": {
         "js-tokens": "^3.0.0 || ^4.0.0"
       }
+    },
+    "macos-release": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/macos-release/-/macos-release-2.3.0.tgz",
+      "integrity": "sha512-OHhSbtcviqMPt7yfw5ef5aghS2jzFVKEFyCJndQt2YpSQ9qRVSEv2axSJI1paVThEu+FFGs584h/1YhxjVqajA=="
     },
     "make-dir": {
       "version": "2.1.0",
@@ -4149,8 +4263,12 @@
     "nice-try": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
-      "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
-      "dev": true
+      "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ=="
+    },
+    "node-fetch": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.0.tgz",
+      "integrity": "sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA=="
     },
     "node-int64": {
       "version": "0.4.0",
@@ -4218,7 +4336,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
       "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
-      "dev": true,
       "requires": {
         "path-key": "^2.0.0"
       }
@@ -4340,11 +4457,15 @@
         "has": "^1.0.3"
       }
     },
+    "octokit-pagination-methods": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/octokit-pagination-methods/-/octokit-pagination-methods-1.1.0.tgz",
+      "integrity": "sha512-fZ4qZdQ2nxJvtcasX7Ghl+WlWS/d9IgnBIwFZXVNNZUmzpno91SX5bc5vuxiuKoCtK78XxGGNuSCrDC7xYB3OQ=="
+    },
     "once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-      "dev": true,
       "requires": {
         "wrappy": "1"
       }
@@ -4395,6 +4516,15 @@
         "wordwrap": "~1.0.0"
       }
     },
+    "os-name": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/os-name/-/os-name-3.1.0.tgz",
+      "integrity": "sha512-h8L+8aNjNcMpo/mAIBPn5PXCM16iyPGjHNWo6U1YO8sJTMHtEtyczI6QJnLoplswm6goopQkqc7OAnjhWcugVg==",
+      "requires": {
+        "macos-release": "^2.2.0",
+        "windows-release": "^3.1.0"
+      }
+    },
     "os-tmpdir": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
@@ -4413,8 +4543,7 @@
     "p-finally": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
-      "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=",
-      "dev": true
+      "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4="
     },
     "p-limit": {
       "version": "1.3.0",
@@ -4485,8 +4614,7 @@
     "path-key": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
-      "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
-      "dev": true
+      "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A="
     },
     "path-parse": {
       "version": "1.0.6",
@@ -4593,7 +4721,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
       "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
-      "dev": true,
       "requires": {
         "end-of-stream": "^1.1.0",
         "once": "^1.3.1"
@@ -4965,7 +5092,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
       "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
-      "dev": true,
       "requires": {
         "shebang-regex": "^1.0.0"
       }
@@ -4973,8 +5099,7 @@
     "shebang-regex": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
-      "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
-      "dev": true
+      "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM="
     },
     "shellwords": {
       "version": "0.1.1",
@@ -4990,8 +5115,7 @@
     "signal-exit": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
-      "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
-      "dev": true
+      "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0="
     },
     "sisteransi": {
       "version": "1.0.3",
@@ -5366,8 +5490,7 @@
     "strip-eof": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
-      "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=",
-      "dev": true
+      "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8="
     },
     "strip-json-comments": {
       "version": "3.0.1",
@@ -5683,6 +5806,14 @@
         "set-value": "^2.0.1"
       }
     },
+    "universal-user-agent": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-4.0.0.tgz",
+      "integrity": "sha512-eM8knLpev67iBDizr/YtqkJsF3GK8gzDc6st/WKzrTuPtcsOKW/0IdL4cnMBsU69pOx0otavLWBDGTwg+dB0aA==",
+      "requires": {
+        "os-name": "^3.1.0"
+      }
+    },
     "unset-value": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/unset-value/-/unset-value-1.0.0.tgz",
@@ -5843,7 +5974,6 @@
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
       "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
-      "dev": true,
       "requires": {
         "isexe": "^2.0.0"
       }
@@ -5853,6 +5983,14 @@
       "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
       "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
       "dev": true
+    },
+    "windows-release": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/windows-release/-/windows-release-3.2.0.tgz",
+      "integrity": "sha512-QTlz2hKLrdqukrsapKsINzqMgOUpQW268eJ0OaOpJN32h272waxR9fkB9VoWRtK7uKHG5EHJcTXQBD8XZVJkFA==",
+      "requires": {
+        "execa": "^1.0.0"
+      }
     },
     "wordwrap": {
       "version": "1.0.0",
@@ -5886,8 +6024,7 @@
     "wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-      "dev": true
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
     },
     "write": {
       "version": "1.0.3",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   },
   "dependencies": {
     "@laboratoria/rubric": "^3.0.3",
+    "@octokit/rest": "^16.30.1",
     "chalk": "^2.4.2",
     "jsdom": "^15.1.1",
     "marked": "^0.7.0",


### PR DESCRIPTION
This PR adds in support to parse courses from Github.

New options:
- token (the access token to read repositories)
- branch (the repository branch to pull contents from) - Corporate Training team maintains multiple courses in different branches.

You can run it with

```bash
curriculum-parser topic https://github.com/Laboratoria/mass-training \
--repo Laboratoria/mass-training \
--branch 05-Onboardingalicorp \
--track business \
--version 1.0.0 \
--locale es-ES \
--token <token> 
```

Please note that the solution is not perfect. We might want to rearchitecture the app to go for clean code.